### PR TITLE
Resolve warn logs & remove redundant DTO field

### DIFF
--- a/src/main/java/net/journeyhero/travelapp/config/JacksonConfig.java
+++ b/src/main/java/net/journeyhero/travelapp/config/JacksonConfig.java
@@ -1,12 +1,16 @@
 package net.journeyhero.travelapp.config;
 
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 import com.fasterxml.jackson.databind.Module;
 import org.n52.jackson.datatype.jts.JtsModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 
 @Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 public class JacksonConfig {
 
     @Bean

--- a/src/main/java/net/journeyhero/travelapp/dto/AttractionRatingRequestDto.java
+++ b/src/main/java/net/journeyhero/travelapp/dto/AttractionRatingRequestDto.java
@@ -7,21 +7,12 @@ import java.util.UUID;
 
 
 public class AttractionRatingRequestDto {
-    private UUID ratingId;
 
     private String attractionName;
     private double attractionLongitude;
     private double attractionLatitude;
     private DisabilityType disabilityType;
     private RatingLevel ratingLevel;
-
-    public UUID getRatingId() {
-        return ratingId;
-    }
-
-    public void setRatingId(UUID ratingId) {
-        this.ratingId = ratingId;
-    }
 
     public String getAttractionName() {
         return attractionName;


### PR DESCRIPTION
Each time we were using the GET REST endpoint, Spring Boot logged a WARN that the internal Page class of Spring was exposed in the response JSON. This is Spring's internal Page class, where Spring might change fields in the future, so it is not recommended to expose it via any API.
With this `pageSerializationMode` change, Spring will instead return a smaller & future-stable DTO representation of its Page class inside the response JSON.

Inside the `AttractionRatingRequestDto` class, the `UUID ratingId` field is not needed, because 
- during a POST operation, the backend itself generates a random UUID when storing to the DB
- during a PUT operation, we use the `ratingId` value from the REST path variable

So we can clean up `AttractionRatingRequestDto` so that it does not contain anything that might confuse the frontend developer.